### PR TITLE
Prefer `/usr/bin/env` over hardcoded executable paths.

### DIFF
--- a/config/lighthouse/cmd
+++ b/config/lighthouse/cmd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while read L; do
   echo "{look! $L|$L}"

--- a/config/lighthouse/cmd.py
+++ b/config/lighthouse/cmd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 
 import sys
 import random

--- a/config/lighthouse/google.py
+++ b/config/lighthouse/google.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Google AJAX Search Module
 http://code.google.com/apis/ajaxsearch/documentation/reference.html


### PR DESCRIPTION
use `/usr/bin/env` to find executables, since it may not always be in the expected place. I never thought I'd be this troll, but since starting to play with NixOS, binaries are all over the place, and I've realized `/usr/bin/env` actually is the enlightened way.
