### PR TITLE
arch AUR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Arch:
     libxcb-xkb
     libxcb-xinerama
 
+Available in AUR as [lighthouse-git](https://aur.archlinux.org/packages/lighthouse-git/)
+
+```
+$ yaourt -S lighthouse-git
+```
+
 Ubuntu:
 
     libpth-dev


### PR DESCRIPTION
added a short blurb point Arch users to the AUR package for installation.
