### PR TITLE
Fix typo in Ubuntu xinerama dependency and add randr

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Ubuntu:
     libx11-xcb-dev
     libcairo2-dev
     libxcb-xkb-dev
-    libxcb-xineram0-dev
+	libxcb-xinerama0-dev
+	libxcb-randr0-dev
 
 NixOS:
 


### PR DESCRIPTION
Fixing a typo in the dependency for xinerama, and added xrandr dependency
