### PR TITLE
Fix non-square images being distorted into a square shape.

### DIFF
--- a/src/lighthouse.c
+++ b/src/lighthouse.c
@@ -330,9 +330,10 @@ static uint32_t draw_image(cairo_t *cr, const char *file, offset_t offset) {
   img = cairo_image_surface_create_from_png(file);
   int w = cairo_image_surface_get_width(img);
   int h = cairo_image_surface_get_height(img);
-  img = scale_surface (img, w, h, settings.height, settings.height);
+  int neww = (int)(((float)(settings.height) * ((float)(w) / (float)(h))) + 0.49999999);
+  img = scale_surface (img, w, h, neww, settings.height);
   h = settings.height;
-  w = settings.height;
+  w = neww;
   /* Attempt to center the image if it is not the height of the line. */ 
   int image_offset = (h - settings.height) / 2;
   cairo_set_source_surface(cr, img, offset.x, offset.image_y - h + image_offset);


### PR DESCRIPTION
In general, all images were rendered at settings.height \* settings.height pixels,
rather than the width being scaled proportionally.

Here is an example of the problem:
![screenshot_491](https://cloud.githubusercontent.com/assets/115782/6726673/049b9894-ce6a-11e4-8b5a-c56e08e8ac20.png)

 The images contain numbers corresponding to their width, and both of their heights is 16. But they are both being stretched to 32x32px, which means the 8x16 one is being quadrupled in width while its height is only doubled. That is a substantial distortion.

With the new behaviour, a 10x16 image with settings.height = 32, will now be rendered at
20 x 32 px,
rather than 32x32 px.
20 being the result of calculating 32 \* (10 / 16).
