### PR TITLE
Added an option to select the _NET_WM_WINDOW_TYPE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ List of settings you can set in the configuration file:
 - `backspace_exit`
 - `cmd`
 - `query_fg`, `query_bg`, `result_fg`, `result_bg`, `hightlight_fg`, `highlight_bg`
+- `dock_mode` (i3 users must set it to 0)
 
 TODO
 ---

--- a/config/lighthouse/lighthouserc
+++ b/config/lighthouse/lighthouserc
@@ -8,3 +8,4 @@ result_bg=0.2,0.2,0.2
 highlight_fg=0.9,0.9,0.9
 highlight_bg=0.2,0.2,0.2
 y=30
+dock_mode=1


### PR DESCRIPTION
Since i3 use a different type of WM_TYPE, I added an option so i3 user don't have to modify the WM_TYPE in the source code.
_NET_WM_WINDOW_DIALOG is enabled by putting dock_mode=0 in lighthouserc (DOCK by default)
