### PR TITLE
Result without action ({test}) are parsed as title.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CFLAGS+=-I$(INCDIR)
 SRCS=$(wildcard $(SRCDIR)/*.c)
 OBJS=$(patsubst $(SRCDIR)/%.c,$(OBJDIR)/%.o,$(SRCS))
 
-CFLAGS+=-O2 -Wall -std=c99 `pkg-config --cflags --libs gtk+-3.0`
+CFLAGS+=-O2 -Wall -std=c99 `pkg-config --cflags --libs gdk-2.0`
 CFLAGS_DEBUG+=-O0 -g3 -Werror -DDEBUG -pedantic
 LDFLAGS+=-lxcb -lxcb-xkb -lxcb-xinerama -lxcb-randr -lcairo -lpthread
 

--- a/config/lighthouse/main.py
+++ b/config/lighthouse/main.py
@@ -11,14 +11,14 @@ import signal
 
 class LocationNotFoundError(Exception):
     def __init__(self, dict_struct=None):
-        print("Location tag should be present in your scripts.json at " + dict_struct)
+       print()
 
 
 def print_out(results):
     print("".join([x if x is not None else "" for x in results]))
 
 
-def clean_subprocesses(processList, subprocess_list):
+def clean_subprocesses(processList, subprocess_list, _exit=0):
     """
     Stop all processes started.
     """
@@ -28,6 +28,8 @@ def clean_subprocesses(processList, subprocess_list):
     for p in subprocess_list:
         p.terminate()
         del p
+    if _exit:
+        exit()
 
 
 def get_result(subprocess, results_array, i):
@@ -67,7 +69,6 @@ def make_commands(scripts_dict):
 
 
 if __name__ == "__main__":
-    signal.signal(signal.SIGTERM, clean_subprocesses)
     subprocess_array = []
     scripts_file = open(os.path.expanduser("~/.config/lighthouse/scripts.json"))
     scripts = json.loads(scripts_file.read())
@@ -75,13 +76,17 @@ if __name__ == "__main__":
     processList = []
     manager = mp.Manager()
     subprocess_list = manager.list()
+    signal.signal(signal.SIGTERM, lambda x, y: clean_subprocesses(processList, subprocess_list, 1))
 
     while 1:
         request = sys.stdin.readline()[:-1]
-
         clean_subprocesses(processList, subprocess_list)
         processList = []
         subprocess_list = manager.list()
+
+        if len(request.strip()) == 0:
+            print('')
+            continue
 
         results_array = manager.list([None for x in range(len(scripts))])
         process_array = []

--- a/config/lighthouse/scripts/basic.py
+++ b/config/lighthouse/scripts/basic.py
@@ -9,7 +9,7 @@ def basic(sett):
         out += "{Execute %%B'%s'%%|%s}" % (sett.user_input,
                                            sett.user_input)
     if sett.show_in_shell:
-        out += "{Run the command in a shell %%B'%s'%%|%s %s}" % (sett.user_input,
+        out += "{Run the command in a shell %%B'%s'%%|%s -e %s}" % (sett.user_input,
                                                                  sett.term,
                                                                  sett.user_input
                                                                  )

--- a/src/display.c
+++ b/src/display.c
@@ -158,11 +158,12 @@ static image_format_t get_new_size(uint32_t width, uint32_t height, uint32_t win
  */
 static void draw_image_with_gdk(cairo_t *cr, const char *file, offset_t offset, uint32_t win_size_x, uint32_t win_size_y, image_format_t *format) {
   GdkPixbuf *image;
-  GError *error;
+  GError *error = NULL;
 
   image = gdk_pixbuf_new_from_file(file, &error);
   if (image == NULL) {
       debug("Image opening failed (tried to open %s): %s\n", file, error->message);
+      g_error_free(error);
       return ;
   }
 

--- a/src/display.c
+++ b/src/display.c
@@ -270,7 +270,7 @@ static void draw_line(cairo_t *cr, const char *text, uint32_t line, color_t *for
       case NEW_LINE:
         break;
       case CENTER:
-        offset.x += (settings.desc_size - d.data_length) / 2;
+        offset.x = (settings.width / 2) - (d.data_length / 2);
       case DRAW_TEXT:
       default:
         offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_NORMAL, settings.font_size);
@@ -337,7 +337,7 @@ static void draw_desc(cairo_t *cr, const char *text, color_t *foreground, color_
         break;
       case CENTER:
         if (d.data_length < settings.desc_size)
-            offset.x += (settings.desc_size - d.data_length) / 2;
+            offset.x = settings.width + (settings.desc_size / 2) - (d.data_length / 2);
       case DRAW_TEXT:
       default:
         offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_NORMAL, settings.desc_font_size);
@@ -414,6 +414,7 @@ void draw_result_text(xcb_connection_t *connection, xcb_window_t window, cairo_t
     if (!(results[index].action)) {
       /* Title */
       draw_line(cr, results[index].text, line, &settings.result_fg, &settings.result_bg);
+      /* TODO Add options for titles. */
     } else if (index != global.result_highlight) {
       draw_line(cr, results[index].text, line, &settings.result_fg, &settings.result_bg);
     } else {

--- a/src/lighthouse.c
+++ b/src/lighthouse.c
@@ -137,8 +137,6 @@ static void get_next_non_title(uint32_t *highlight) {
  * @param Copy of the global.result_highlight for the ease of use.
  */
 static void get_next_line(uint32_t *highlight) {
-      if (!*highlight)
-          global.result_offset = 0;
       get_next_non_title(highlight);
       if(global.results[*highlight].action &&
               *highlight == global.result_count) {
@@ -170,9 +168,9 @@ static void get_previous_non_title(uint32_t *highlight) {
  * @param Copy of the global.result_highlight for the ease of use.
  */
 static void get_previous_line(uint32_t *highlight) {
-    if (*highlight) {
+    if (*highlight)
         get_previous_non_title(highlight);
-    }
+
     if(!*highlight) {
         *highlight = global.result_count;
         get_previous_non_title(highlight);
@@ -221,6 +219,7 @@ static inline int32_t process_key_stroke(xcb_window_t window, char *query_buffer
       if (highlight == global.result_count) {
         /* highlight hit the bottom. */
         highlight = 0;
+        global.result_offset = 0;
         while (highlight < global.result_count - 1 && global.results[highlight].action) {
             highlight++;
         }

--- a/src/lighthouse.c
+++ b/src/lighthouse.c
@@ -138,8 +138,7 @@ static void get_next_non_title(uint32_t *highlight) {
  */
 static void get_next_line(uint32_t *highlight) {
       get_next_non_title(highlight);
-      if(global.results[*highlight].action &&
-              *highlight == global.result_count) {
+      if(*highlight == global.result_count) {
           /* If the last result is a title go on the top. */
           *highlight = -1;
           global.result_offset = 0;
@@ -155,8 +154,12 @@ static void get_next_line(uint32_t *highlight) {
  */
 static void get_previous_non_title(uint32_t *highlight) {
     (*highlight)--;
-    while ((*highlight) > (uint32_t) -1 && !global.results[*highlight].action) {
-        /* Searching for the previous result with an action.*/
+    while ((*highlight) < global.result_count && !global.results[*highlight].action) {
+        /* Searching for the previous result with an action.
+         *
+         * *(*highlight) < global.result_count is used because I use highlight is
+         * unsigned so it when it hit "-1", it's bigger than global.result_count
+         */
         (*highlight)--;
     }
 }
@@ -170,7 +173,7 @@ static void get_previous_non_title(uint32_t *highlight) {
 static void get_previous_line(uint32_t *highlight) {
     get_previous_non_title(highlight);
 
-    if(*highlight == (uint32_t) -1) {
+    if(*highlight == (uint32_t) - 1) {
         *highlight = global.result_count;
         get_previous_non_title(highlight);
     }
@@ -246,6 +249,7 @@ static inline int32_t process_key_stroke(xcb_window_t window, char *query_buffer
   switch (key) {
     case 65293: /* Enter. */
       if (global.results && global.result_highlight < global.result_count) {
+        printf("%s", global.results[global.result_highlight].action);
         goto cleanup;
       }
       break;

--- a/src/lighthouse.c
+++ b/src/lighthouse.c
@@ -141,7 +141,7 @@ static void get_next_line(uint32_t *highlight) {
       if(global.results[*highlight].action &&
               *highlight == global.result_count) {
           /* If the last result is a title go on the top. */
-          *highlight = 0;
+          *highlight = -1;
           global.result_offset = 0;
           get_next_non_title(highlight);
       }
@@ -155,7 +155,7 @@ static void get_next_line(uint32_t *highlight) {
  */
 static void get_previous_non_title(uint32_t *highlight) {
     (*highlight)--;
-    while ((*highlight) > 0 && !global.results[*highlight].action) {
+    while ((*highlight) > (uint32_t) -1 && !global.results[*highlight].action) {
         /* Searching for the previous result with an action.*/
         (*highlight)--;
     }
@@ -168,10 +168,9 @@ static void get_previous_non_title(uint32_t *highlight) {
  * @param Copy of the global.result_highlight for the ease of use.
  */
 static void get_previous_line(uint32_t *highlight) {
-    if (*highlight)
-        get_previous_non_title(highlight);
+    get_previous_non_title(highlight);
 
-    if(!*highlight) {
+    if(*highlight == (uint32_t) -1) {
         *highlight = global.result_count;
         get_previous_non_title(highlight);
     }

--- a/src/lighthouse.c
+++ b/src/lighthouse.c
@@ -104,6 +104,8 @@ static void get_next_non_title(uint32_t *highlight) {
  * @param Copy of the global.result_highlight for the ease of use.
  */
 static void get_next_line(uint32_t *highlight) {
+      if (!*highlight)
+          global.result_offset = 0;
       get_next_non_title(highlight);
       if(global.results[*highlight].action &&
               *highlight == global.result_count) {

--- a/src/lighthouse.c
+++ b/src/lighthouse.c
@@ -246,7 +246,6 @@ static inline int32_t process_key_stroke(xcb_window_t window, char *query_buffer
   switch (key) {
     case 65293: /* Enter. */
       if (global.results && global.result_highlight < global.result_count) {
-        printf("%s", global.results[global.result_highlight].action);
         goto cleanup;
       }
       break;

--- a/src/results.c
+++ b/src/results.c
@@ -194,8 +194,13 @@ uint32_t parse_result_text(char *text, size_t length, result_t **results) {
         free(ret);
         return 0;
       }
+      if (mode == 1) {
+        /* if no action */
+        ret[count - 1].action = NULL;
+        ret[count - 1].desc = NULL;
+      }
       if (mode == 2) {
-        /* if no description was used in the user script. */
+        /* if no description */
         ret[count - 1].desc = NULL;
       }
       text[index] = 0;

--- a/src/results.c
+++ b/src/results.c
@@ -172,17 +172,15 @@ uint32_t parse_result_text(char *text, size_t length, result_t **results) {
     }
     /* Split brace. */
     else if (text[index] == '|') {
-      if ((mode != 1) && (mode != 2)) {
+      text[index] = 0;
+      if (mode == 0) {
         fprintf(stderr, "Syntax error, found | at index %d.\n %s\n", index, text);
         free(ret);
         return 0;
-      }
-      text[index] = 0;
-      if ((index + 1 < length) && (mode == 1)){
+      } else if ((index + 1 < length) && (mode == 1)){
         ret[count - 1].action = &(text[index+1]);
         /* Can be a description or an action */
-      }
-      if ((index + 1 < length) && (mode == 2)){
+      } else if ((index + 1 < length) && (mode == 2)){
         ret[count - 1].desc = &(text[index+1]);
       }
       mode++;


### PR DESCRIPTION
- Title are non "clickable"

Added two shortcut:
- Ctrl-D: Go below the next title.
- Ctrl-U: Go above the previous title.
  (Modifiers are now usable)
