### PR TITLE
Added pango lib to draw text.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,14 @@ ifdef $(HAS_GDK)
 else
 	CFLAGS+=-DNO_GDK
 endif
+HAS_GDK := $(shell pkg-config --exists pango echo $?)
+ifdef $(HAS_GDK)
+	CFLAGS+=`pkg-config --cflags pango`
+	LDFLAGS+=`pkg-config --libs pango`
+else
+	CFLAGS+=-DNO_PANGO
+endif
+
 
 all: lighthouse
 

--- a/src/display.c
+++ b/src/display.c
@@ -104,11 +104,13 @@ static void draw_typed_line(cairo_t *cr, char *text, uint32_t line, uint32_t cur
   pthread_mutex_unlock(&global.draw_mutex);
 }
 
+#ifndef NO_PANGO
 /* @brief Draw text at the given offset.
  *
  * @param cr A cairo context for drawing to the screen.
  * @param text The text to be drawn.
  * @param foreground The color of the text.
+ * @param font_description pango font description provide info on the font.
  * @return The advance in the x direction.
  */
 static uint32_t draw_text(cairo_t *cr, const char *text, offset_t offset, color_t *foreground, PangoFontDescription *font_description) {
@@ -131,6 +133,25 @@ static uint32_t draw_text(cairo_t *cr, const char *text, offset_t offset, color_
 
   return width;
 }
+#else
+/* @brief Draw text at the given offset.
+ *
+ * @param cr A cairo context for drawing to the screen.
+ * @param text The text to be drawn.
+ * @param foreground The color of the text.
+ * @return The advance in the x direction.
+ */
+static uint32_t draw_text(cairo_t *cr, const char *text, offset_t offset, color_t *foreground, cairo_font_weight_t weight, uint32_t font_size) {
+    cairo_text_extents_t extents;
+    cairo_text_extents(cr, text, &extents);
+    cairo_move_to(cr, offset.x, offset.y);
+    cairo_set_source_rgb(cr, foreground->r, foreground->g, foreground->b);
+    cairo_select_font_face(cr, settings.font_name, CAIRO_FONT_SLANT_NORMAL, weight);
+    cairo_set_font_size(cr, font_size);
+    cairo_show_text(cr, text);
+    return extents.x_advance;
+}
+#endif
 
 #ifndef NO_GDK
 /* @brief Return the new format for a picture to fit in a window.
@@ -329,16 +350,22 @@ static void draw_line(cairo_t *cr, const char *text, uint32_t line, color_t *for
   cairo_fill(cr);
   offset_t offset = calculate_line_offset(line);
 
+#ifndef NO_PANGO
   PangoFontDescription *font_description;
   font_description = pango_font_description_new();
   pango_font_description_set_family(font_description, settings.font_name);
   pango_font_description_set_weight(font_description, PANGO_WEIGHT_NORMAL);
   pango_font_description_set_absolute_size(font_description, settings.font_size * PANGO_SCALE);
+#endif
 
   /* Parse the result line as we draw it. */
   char *c = (char *)text;
   while (c && *c != '\0') {
+#ifndef NO_PANGO
     draw_t d = parse_result_line(cr, &c, settings.width - offset.x, font_description);
+#else
+    draw_t d = parse_result_line(cr, &c, settings.width - offset.x);
+#endif
     if (d.data == NULL)
         break;
     /* Checking if there are still char to draw. */
@@ -352,8 +379,12 @@ static void draw_line(cairo_t *cr, const char *text, uint32_t line, color_t *for
         offset.x += format.width;
         break;
       case BOLD:
+#ifndef NO_PANGO
         pango_font_description_set_weight(font_description, PANGO_WEIGHT_BOLD);
         offset.x += draw_text(cr, d.data, offset, foreground, font_description);
+#else
+        offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_NORMAL, settings.font_size);
+#endif
         break;
       case DRAW_LINE:
       case NEW_LINE:
@@ -362,13 +393,19 @@ static void draw_line(cairo_t *cr, const char *text, uint32_t line, color_t *for
         offset.x = (settings.width - d.data_length) / 2;
       case DRAW_TEXT:
       default:
+#ifndef NO_PANGO
         pango_font_description_set_weight(font_description, PANGO_WEIGHT_NORMAL);
         offset.x += draw_text(cr, d.data, offset, foreground, font_description);
+#else
+        offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_BOLD, settings.font_size);
+#endif
         break;
     }
     *c = saved;
   }
+#ifndef NO_PANGO
   pango_font_description_free (font_description);
+#endif
   pthread_mutex_unlock(&global.draw_mutex);
 }
 
@@ -390,16 +427,22 @@ static void draw_desc(cairo_t *cr, const char *text, color_t *foreground, color_
   cairo_fill(cr);
   offset_t offset = {settings.width + 2, global.real_desc_font_size, 0};
 
+#ifndef NO_PANGO
   PangoFontDescription *font_description;
   font_description = pango_font_description_new();
   pango_font_description_set_family(font_description, settings.font_name);
   pango_font_description_set_weight(font_description, PANGO_WEIGHT_NORMAL);
   pango_font_description_set_absolute_size(font_description, settings.desc_font_size * PANGO_SCALE);
+#endif
 
   /* Parse the result line as we draw it. */
   char *c = (char *)text;
   while (c && *c != '\0') {
+#ifndef NO_PANGO
     draw_t d = parse_result_line(cr, &c, settings.desc_size + settings.width - offset.x, font_description);
+#else
+    draw_t d = parse_result_line(cr, &c, settings.width - offset.x);
+#endif
     char saved = *c;
     *c = '\0';
     switch (d.type) {
@@ -429,16 +472,24 @@ static void draw_desc(cairo_t *cr, const char *text, color_t *foreground, color_
         offset.image_y += global.real_desc_font_size;
         break;
       case BOLD:
+#ifndef NO_PANGO
         pango_font_description_set_weight(font_description, PANGO_WEIGHT_BOLD);
         offset.x += draw_text(cr, d.data, offset, foreground, font_description);
+#else
+        offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_NORMAL, settings.font_size);
+#endif
         break;
       case CENTER:
         if (d.data_length < settings.desc_size)
             offset.x = settings.width + (settings.desc_size - d.data_length) / 2;
       case DRAW_TEXT:
       default:
+#ifndef NO_PANGO
         pango_font_description_set_weight(font_description, PANGO_WEIGHT_NORMAL);
         offset.x += draw_text(cr, d.data, offset, foreground, font_description);
+#else
+        offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_BOLD, settings.font_size);
+#endif
         break;
     }
     *c = saved;
@@ -449,7 +500,9 @@ static void draw_desc(cairo_t *cr, const char *text, color_t *foreground, color_
         offset.image_y += global.real_desc_font_size;
     }
   }
+#ifndef NO_PANGO
   pango_font_description_free (font_description);
+#endif
   pthread_mutex_unlock(&global.draw_mutex);
 }
 

--- a/src/display.c
+++ b/src/display.c
@@ -111,15 +111,25 @@ static void draw_typed_line(cairo_t *cr, char *text, uint32_t line, uint32_t cur
  * @param foreground The color of the text.
  * @return The advance in the x direction.
  */
-static uint32_t draw_text(cairo_t *cr, const char *text, offset_t offset, color_t *foreground, cairo_font_weight_t weight, uint32_t font_size) {
-  cairo_text_extents_t extents;
-  cairo_text_extents(cr, text, &extents);
+static uint32_t draw_text(cairo_t *cr, const char *text, offset_t offset, color_t *foreground, PangoFontDescription *font_description) {
+  PangoLayout *layout;
+  layout = pango_cairo_create_layout(cr);
+  pango_layout_set_font_description(layout, font_description);
+  pango_layout_set_text (layout, text, -1);
+
   cairo_move_to(cr, offset.x, offset.y);
   cairo_set_source_rgb(cr, foreground->r, foreground->g, foreground->b);
-  cairo_select_font_face(cr, settings.font_name, CAIRO_FONT_SLANT_NORMAL, weight);
-  cairo_set_font_size(cr, font_size);
-  cairo_show_text(cr, text);
-  return extents.x_advance;
+  pango_cairo_update_layout(cr, layout);
+
+  int height;
+  int width;
+  pango_layout_get_pixel_size(layout, &width, &height);
+
+  pango_cairo_show_layout_line(cr, pango_layout_get_line (layout, 0));
+
+  g_object_unref(layout);
+
+  return width;
 }
 
 #ifndef NO_GDK
@@ -319,10 +329,16 @@ static void draw_line(cairo_t *cr, const char *text, uint32_t line, color_t *for
   cairo_fill(cr);
   offset_t offset = calculate_line_offset(line);
 
+  PangoFontDescription *font_description;
+  font_description = pango_font_description_new();
+  pango_font_description_set_family(font_description, settings.font_name);
+  pango_font_description_set_weight(font_description, PANGO_WEIGHT_NORMAL);
+  pango_font_description_set_absolute_size(font_description, settings.font_size * PANGO_SCALE);
+
   /* Parse the result line as we draw it. */
   char *c = (char *)text;
   while (c && *c != '\0') {
-    draw_t d = parse_result_line(cr, &c, settings.width - offset.x);
+    draw_t d = parse_result_line(cr, &c, settings.width - offset.x, font_description);
     if (d.data == NULL)
         break;
     /* Checking if there are still char to draw. */
@@ -336,21 +352,23 @@ static void draw_line(cairo_t *cr, const char *text, uint32_t line, color_t *for
         offset.x += format.width;
         break;
       case BOLD:
-        offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_BOLD, settings.font_size);
+        pango_font_description_set_weight(font_description, PANGO_WEIGHT_BOLD);
+        offset.x += draw_text(cr, d.data, offset, foreground, font_description);
         break;
       case DRAW_LINE:
       case NEW_LINE:
         break;
       case CENTER:
-        offset.x = (settings.width / 2) - (d.data_length / 2);
+        offset.x = (settings.width - d.data_length) / 2;
       case DRAW_TEXT:
       default:
-        offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_NORMAL, settings.font_size);
+        pango_font_description_set_weight(font_description, PANGO_WEIGHT_NORMAL);
+        offset.x += draw_text(cr, d.data, offset, foreground, font_description);
         break;
     }
     *c = saved;
   }
-
+  pango_font_description_free (font_description);
   pthread_mutex_unlock(&global.draw_mutex);
 }
 
@@ -372,10 +390,16 @@ static void draw_desc(cairo_t *cr, const char *text, color_t *foreground, color_
   cairo_fill(cr);
   offset_t offset = {settings.width + 2, global.real_desc_font_size, 0};
 
+  PangoFontDescription *font_description;
+  font_description = pango_font_description_new();
+  pango_font_description_set_family(font_description, settings.font_name);
+  pango_font_description_set_weight(font_description, PANGO_WEIGHT_NORMAL);
+  pango_font_description_set_absolute_size(font_description, settings.desc_font_size * PANGO_SCALE);
+
   /* Parse the result line as we draw it. */
   char *c = (char *)text;
   while (c && *c != '\0') {
-    draw_t d = parse_result_line(cr, &c, settings.desc_size + settings.width - offset.x);
+    draw_t d = parse_result_line(cr, &c, settings.desc_size + settings.width - offset.x, font_description);
     char saved = *c;
     *c = '\0';
     switch (d.type) {
@@ -405,14 +429,16 @@ static void draw_desc(cairo_t *cr, const char *text, color_t *foreground, color_
         offset.image_y += global.real_desc_font_size;
         break;
       case BOLD:
-        offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_BOLD, settings.desc_font_size);
+        pango_font_description_set_weight(font_description, PANGO_WEIGHT_BOLD);
+        offset.x += draw_text(cr, d.data, offset, foreground, font_description);
         break;
       case CENTER:
         if (d.data_length < settings.desc_size)
-            offset.x = settings.width + (settings.desc_size / 2) - (d.data_length / 2);
+            offset.x = settings.width + (settings.desc_size - d.data_length) / 2;
       case DRAW_TEXT:
       default:
-        offset.x += draw_text(cr, d.data, offset, foreground, CAIRO_FONT_WEIGHT_NORMAL, settings.desc_font_size);
+        pango_font_description_set_weight(font_description, PANGO_WEIGHT_NORMAL);
+        offset.x += draw_text(cr, d.data, offset, foreground, font_description);
         break;
     }
     *c = saved;
@@ -423,7 +449,7 @@ static void draw_desc(cairo_t *cr, const char *text, color_t *foreground, color_
         offset.image_y += global.real_desc_font_size;
     }
   }
-
+  pango_font_description_free (font_description);
   pthread_mutex_unlock(&global.draw_mutex);
 }
 

--- a/src/inc/display.h
+++ b/src/inc/display.h
@@ -10,6 +10,8 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gdk/gdk.h>
 #include <glib.h>
+#endif
+#ifndef NO_PANGO
 #include <pango/pangocairo.h>
 #endif
 

--- a/src/inc/display.h
+++ b/src/inc/display.h
@@ -10,6 +10,7 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gdk/gdk.h>
 #include <glib.h>
+#include <pango/pangocairo.h>
 #endif
 
 #include "results.h"

--- a/src/inc/results.h
+++ b/src/inc/results.h
@@ -3,7 +3,9 @@
 
 #include <cairo/cairo.h>
 #include <cairo/cairo-xcb.h>
+#ifndef NO_PANGO
 #include <pango/pangocairo.h>
+#endif
 
 /* @brief The type of data to draw. */
 typedef enum {
@@ -38,7 +40,11 @@ struct result_params {
   int32_t fd;
 };
 
+#ifndef NO_PANGO
 draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length, PangoFontDescription *font_description);
+#else
+draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length);
+#endif
 uint32_t parse_result_text(char *text, size_t length, result_t **results);
 void *get_results(void *args);
 

--- a/src/inc/results.h
+++ b/src/inc/results.h
@@ -3,6 +3,7 @@
 
 #include <cairo/cairo.h>
 #include <cairo/cairo-xcb.h>
+#include <pango/pangocairo.h>
 
 /* @brief The type of data to draw. */
 typedef enum {
@@ -37,7 +38,7 @@ struct result_params {
   int32_t fd;
 };
 
-draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length);
+draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length, PangoFontDescription *font_description);
 uint32_t parse_result_text(char *text, size_t length, result_t **results);
 void *get_results(void *args);
 

--- a/src/results.c
+++ b/src/results.c
@@ -32,7 +32,11 @@ static void get_in(char **c, char **data) {
  * @param line_length length in pixel of the line.
  * @return A populated draw_t type.
  */
+#ifndef NO_PANGO
 draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length, PangoFontDescription *font_description) {
+#else
+draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length) {
+#endif
   if (!c || !*c) {
     fprintf(stderr, "Invalid parse state");
     return (draw_t){ DRAW_TEXT, NULL }; /* This will invoke a segfault most likely. */
@@ -53,6 +57,7 @@ draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length, PangoFontD
         type = CENTER;
         get_in(c, &data);
 
+#ifndef NO_PANGO
         PangoLayout *layout;
         layout = pango_cairo_create_layout(cr);
         pango_layout_set_font_description(layout, font_description);
@@ -71,6 +76,16 @@ draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length, PangoFontD
         data_length -= end_width;
 
         g_object_unref(layout);
+#else
+        cairo_text_extents_t extents;
+        /* http://cairographics.org/manual/cairo-cairo-scaled-font-t.html#cairo-text-extents-t
+         * For more information on cairo text extents.
+         */
+        cairo_text_extents(cr, data, &extents);
+        data_length = extents.x_advance;
+        cairo_text_extents(cr, *c, &extents);
+        data_length -= extents.x_advance;
+#endif
         break;
       case 'B':
         type = BOLD;
@@ -102,16 +117,24 @@ draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length, PangoFontD
     }
     type = DRAW_TEXT;
 
+#ifndef NO_PANGO
     PangoLayout *layout;
     layout = pango_cairo_create_layout(cr);
     pango_layout_set_font_description(layout, font_description);
     pango_layout_set_text(layout, *c, -1);
     pango_cairo_update_layout(cr, layout);
 
-    int height;
     int width;
-    pango_layout_get_pixel_size(layout, &width, &height);
+    pango_layout_get_pixel_size(layout, &width, NULL);
     data_length = width;
+#else
+    cairo_text_extents_t extents;
+    /* http://cairographics.org/manual/cairo-cairo-scaled-font-t.html#cairo-text-extents-t
+     * For more information on cairo text extents.
+     */
+    cairo_text_extents(cr, data, &extents);
+    data_length = extents.x_advance;
+#endif
     /* length of the line from the "data" variable position */
     if (data_length > line_length) {
         /* Checking if the text is long enough to exceed the line length
@@ -120,12 +143,15 @@ draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length, PangoFontD
         while (**c != '\0' && **c != '%'
                && !(**c == '\\' && *(*c + 1) == '%')) {
             *c += 1;
+#ifndef NO_PANGO
             pango_layout_set_text(layout, *c, -1);
             pango_cairo_update_layout(cr, layout);
-            int height;
-            int width;
-            pango_layout_get_pixel_size(layout, &width, &height);
+            pango_layout_get_pixel_size(layout, &width, NULL);
             if ((data_length - width) > line_length) {
+#else
+            cairo_text_extents(cr, *c, &extents);
+            if ((data_length - extents.x_advance) > line_length) {
+#endif
                 /* data_length - extents.x_advance let us know the
                  * length of the current line.
                  */
@@ -141,7 +167,9 @@ draw_t parse_result_line(cairo_t *cr, char **c, uint32_t line_length, PangoFontD
             *c += 1;
         }
     }
+#ifndef NO_PANGO
     g_object_unref(layout);
+#endif
   }
 
   return (draw_t){ type, data, data_length };


### PR DESCRIPTION
It fix white screen issue ( https://github.com/emgram769/lighthouse/issues/33 ) for weird special character.
But the basic text drawing functions of cairo are still usable if lighthouse is compiled without pango lib.
