### PR TITLE
Remove "CC=gcc"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ PREFIX = /usr/local
 SHAREPREFIX = ${PREFIX}/share/lighthouse
 DOLLAR = $$
 
-CC=gcc
 CFLAGS+=-I$(INCDIR)
 
 OBJDIR=objs

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PREFIX = /usr/local
 SHAREPREFIX = ${PREFIX}/share/lighthouse
 DOLLAR = $$
 
+CC?=gcc
 CFLAGS+=-I$(INCDIR)
 
 OBJDIR=objs


### PR DESCRIPTION
This doesn't seem to work well on some systems (including FreeBSD)