### PR TITLE
Fix python shabang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PREFIX = /usr/local
 SHAREPREFIX = ${PREFIX}/share/lighthouse
 DOLLAR = $$
 
-CC=gcc
+# CC=gcc
 CFLAGS+=-I$(INCDIR)
 
 OBJDIR=objs

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PREFIX = /usr/local
 SHAREPREFIX = ${PREFIX}/share/lighthouse
 DOLLAR = $$
 
-# CC=gcc
+CC?=gcc
 CFLAGS+=-I$(INCDIR)
 
 OBJDIR=objs

--- a/config/lighthouse/cmd.py
+++ b/config/lighthouse/cmd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 
 import sys
 import random

--- a/config/lighthouse/main.py
+++ b/config/lighthouse/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import multiprocessing as mp
 import shlex


### PR DESCRIPTION
`/usr/bin/python` is non-existent on some systems as it resides in `/usr/local/bin`